### PR TITLE
Stop dependabot from notifying about flyway updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+  ignore:
+    - dependency-name: "org.flywaydb.flyway"
 
 - package-ecosystem: "github-actions"
   directory: "/"


### PR DESCRIPTION
We use the same flyway as spring boot.

Also test sonar on a PR.
