### PR TITLE
Make GetIdleTimeLinux.XScreenSaverInfo accessible to com.sun.jna.Structure

### DIFF
--- a/app/src/main/java/io/xeres/app/xrs/service/status/idletimer/GetIdleTimeLinux.java
+++ b/app/src/main/java/io/xeres/app/xrs/service/status/idletimer/GetIdleTimeLinux.java
@@ -29,7 +29,7 @@ import io.xeres.app.xrs.service.status.GetIdleTime;
 public class GetIdleTimeLinux implements GetIdleTime
 {
 	@SuppressWarnings("unused")
-	private static class XScreenSaverInfo extends Structure
+	public static class XScreenSaverInfo extends Structure
 	{
 		public X11.Window window;
 		public int state;


### PR DESCRIPTION
I've been getting a lot of these on Linux:
```
java.lang.Error: Exception reading field 'window' in class io.xeres.app.xrs.service.status.idletimer.GetIdleTimeLinux$XScreenSaverInfo
        at com.sun.jna.Structure.initializeFields(Structure.java:1420) ~[jna-5.15.0.jar:5.15.0 (b0)]
        at com.sun.jna.Structure.<init>(Structure.java:218) ~[jna-5.15.0.jar:5.15.0 (b0)]
        at com.sun.jna.Structure.<init>(Structure.java:204) ~[jna-5.15.0.jar:5.15.0 (b0)]
        at com.sun.jna.Structure.<init>(Structure.java:191) ~[jna-5.15.0.jar:5.15.0 (b0)]
        at com.sun.jna.Structure.<init>(Structure.java:183) ~[jna-5.15.0.jar:5.15.0 (b0)]
        at io.xeres.app.xrs.service.status.idletimer.GetIdleTimeLinux$XScreenSaverInfo.<init>(GetIdleTimeLinux.java:32) ~[main/:na]
        at io.xeres.app.xrs.service.status.idletimer.GetIdleTimeLinux.getIdleTime(GetIdleTimeLinux.java:63) ~[main/:na]
        at io.xeres.app.xrs.service.status.IdleChecker.getIdleTime(IdleChecker.java:36) ~[main/:na]
        at io.xeres.app.job.IdleDetectionJob.checkIdle(IdleDetectionJob.java:61) ~[main/:na]
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103) ~[na:na]
        at java.base/java.lang.reflect.Method.invoke(Method.java:580) ~[na:na]
        at org.springframework.scheduling.support.ScheduledMethodRunnable.runInternal(ScheduledMethodRunnable.java:130) ~[spring-context-6.2.0.jar:6.2.0]
        at org.springframework.scheduling.support.ScheduledMethodRunnable.lambda$run$2(ScheduledMethodRunnable.java:124) ~[spring-context-6.2.0.jar:6.2.0]
        at io.micrometer.observation.Observation.observe(Observation.java:499) ~[micrometer-observation-1.14.1.jar:1.14.1]
        at org.springframework.scheduling.support.ScheduledMethodRunnable.run(ScheduledMethodRunnable.java:124) ~[spring-context-6.2.0.jar:6.2.0]
        at org.springframework.scheduling.config.Task$OutcomeTrackingRunnable.run(Task.java:83) ~[spring-context-6.2.0.jar:6.2.0]
        at org.springframework.scheduling.support.DelegatingErrorHandlingRunnable.run(DelegatingErrorHandlingRunnable.java:54) ~[spring-context-6.2.0.jar:6.2.
0]
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572) ~[na:na]
        at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:358) ~[na:na]
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305) ~[na:na]
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144) ~[na:na]
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642) ~[na:na]
        at java.base/java.lang.Thread.run(Thread.java:1583) ~[na:na]
Caused by: java.lang.IllegalAccessException: class com.sun.jna.Structure cannot access a member of class io.xeres.app.xrs.service.status.idletimer.GetIdleTime
Linux$XScreenSaverInfo with modifiers "public"
        at java.base/jdk.internal.reflect.Reflection.newIllegalAccessException(Reflection.java:394) ~[na:na]
        at java.base/java.lang.reflect.AccessibleObject.checkAccess(AccessibleObject.java:714) ~[na:na]
        at java.base/java.lang.reflect.Field.checkAccess(Field.java:1156) ~[na:na]
        at java.base/java.lang.reflect.Field.get(Field.java:441) ~[na:na]
        at com.sun.jna.Structure.initializeFields(Structure.java:1414) ~[jna-5.15.0.jar:5.15.0 (b0)]
        ... 22 common frames omitted
```
As a quick fix, I made `GetIdleTime.XScreenSaverInfo` public, so that it is accessible to `com.sun.jna.Structure`.
Not sure this is the right way to fix it though.